### PR TITLE
Configure Jansson to only allocate 4 hashtable buckets for empty object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ include $(BUILD_DIR)/Makefile.library.mk
 #
 CONFIG_H = $(SOURCE_DIR)/jansson_config.h
 
-$(CONFIG_H):
-	@cp $(PROJ_DIR)/armcc/jansson_config.h $(CONFIG_H)
+$(CONFIG_H): $(PROJ_DIR)/armcc/jansson_config.h
+	@cp $< $@
 
 $(OBJS): $(CONFIG_H)
 

--- a/Makefile.cppunit
+++ b/Makefile.cppunit
@@ -22,8 +22,8 @@ OBJS += src/strconv.o
 OBJS += src/utf.o
 OBJS += src/value.o
 
-src/jansson_config.h:
-	cp cppunit/jansson_config.h $@
+src/jansson_config.h: cppunit/jansson_config.h
+	cp $< $@
 
 src/%.o: src/%.c $(HEADERS)
 	$(CC) $(CFLAGS) $(PROFILE_FLAGS) -c $< -o $@

--- a/armcc/jansson_config.h
+++ b/armcc/jansson_config.h
@@ -36,4 +36,10 @@
    otherwise to 0. */
 #define JSON_HAVE_LOCALECONV 0
 
+/* Number of buckets new object hashtables contain is 2 raised to this power. The default is 3,
+   so empty hashtables contain 2^3 = 8 buckets. We use 2, so empty hashtables contain 2^2 = 4 
+   buckets. */
+#define INITIAL_HASHTABLE_ORDER 2
+
+
 #endif

--- a/cppunit/jansson_config.h
+++ b/cppunit/jansson_config.h
@@ -36,4 +36,9 @@
    otherwise to 0. */
 #define JSON_HAVE_LOCALECONV 0
 
+/* Number of buckets new object hashtables contain is 2 raised to this power. The default is 3,
+   so empty hashtables contain 2^3 = 8 buckets. We use 2, so empty hashtables contain 2^2 = 4 
+   buckets. */
+#define INITIAL_HASHTABLE_ORDER 2
+
 #endif


### PR DESCRIPTION
OK, I already merged the latest master from Jansson this morning. The only actual code change was a slight variation of the PR I submitted to them (see https://github.com/akheron/jansson/commit/abaae7630ec9df0adca1ec012ddbcc4b211e54f1). Oh, I guess there was one lex flag change that shouldn't effect us either.

Nonetheless, this PR uses the capability supplied in the mentioned commit to move our initial hashtable number of buckets down to 4, which fits into a 32 byte block. This should significantly reduce our usage of 64 byte blocks.

Doing this actually breaks our unit tests slightly because of the hashing algorithm behaves differently with the smaller initial buckets. I'll have another PR coming to fix that.
