### PR TITLE
TOOLS: Add mutex protection for jansson reference counts

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -41,6 +41,7 @@ static JSON_INLINE void json_init(json_t *json, json_type type)
 {
     json->type = type;
     json->refcount = 1;
+    pthread_mutex_init(&json->refmutex, 0);
 }
 
 
@@ -946,6 +947,7 @@ void json_delete(json_t *json)
     else if(json_is_real(json))
         json_delete_real(json_to_real(json));
 
+    pthread_mutex_destroy(&json->refmutex);
     /* json_delete is not called for true, false or null */
 }
 


### PR DESCRIPTION
We're using json objects from multiple threads in a way that needs some protection. (This is the source of recent instability in the posix port.) Without completely changing how we're using jansson, this is the only reasonable solution I see to the problem.

It would be better if we could figure out a way to use C11 atomics for this; but this gets us past the immediate problem, so I'm putting it in. No chance of this being accepted upstream, I'm sure. Maybe conditional atomics would be.