### PR TITLE
DE3529: When dumping JSON to a file, proactively sync file contents.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <unistd.h>
 
 #include "jansson.h"
 #include "jansson_private.h"
@@ -448,6 +449,7 @@ int json_dump_file(const json_t *json, const char *path, size_t flags)
 
     result = json_dumpf(json, output, flags);
 
+    fdatasync(fileno(output));
     fclose(output);
     return result;
 }


### PR DESCRIPTION
Goes along with an `xl` PR.

We're trying to remove our global [`sync`](http://linux.die.net/man/2/sync) call, in favor of a more localized [`fsync` or `fdatasync`](http://linux.die.net/man/2/fsync) call after each of our file writes.

The latter call has to be made when we still have access to a file descriptor, which means we're here in Jansson as opposed to a level above.