### PR TITLE
US2231, TA7590: Allow xl build finer grain control of library output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ include $(BUILD_DIR)/makefile.d/base.mk
 
 CFLAGS += -Isrc -DHAVE_STDINT_H=1
 
-JANSSON_A = $(OUTPUT_DIR)/libjansson.a
+# Fall back to OUTPUT_DIR. Keeps this build working if there is a mismatch with the xl repo.
+LIBRARY_OUTPUT_DIR ?= $(OUTPUT_DIR)
+
+JANSSON_A = $(LIBRARY_OUTPUT_DIR)/libjansson.a
 
 HEADERS += src/jansson.h
 HEADERS += src/jansson_config.h
@@ -12,31 +15,32 @@ HEADERS += src/strbuffer.h
 HEADERS += src/utf.h
 HEADERS += src/jansson_private.h
 
-OBJS += $(OUTPUT_DIR)/dump.o
-OBJS += $(OUTPUT_DIR)/error.o
-OBJS += $(OUTPUT_DIR)/hashtable.o
-OBJS += $(OUTPUT_DIR)/hashtable_seed.o
-OBJS += $(OUTPUT_DIR)/load.o
-OBJS += $(OUTPUT_DIR)/memory.o
-OBJS += $(OUTPUT_DIR)/pack_unpack.o
-OBJS += $(OUTPUT_DIR)/strbuffer.o
-OBJS += $(OUTPUT_DIR)/strconv.o
-OBJS += $(OUTPUT_DIR)/utf.o
-OBJS += $(OUTPUT_DIR)/value.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/dump.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/error.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/hashtable.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/hashtable_seed.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/load.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/memory.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/pack_unpack.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/strbuffer.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/strconv.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/utf.o
+OBJS += $(LIBRARY_OUTPUT_DIR)/value.o
 
 src/jansson_config.h: cppunit/jansson_config.h
 	cp $< $@
 
-$(OUTPUT_DIR):
-	$(VERBOSE)mkdir -p $(OUTPUT_DIR)
+$(LIBRARY_OUTPUT_DIR):
+	$(VERBOSE)mkdir -p $(LIBRARY_OUTPUT_DIR)
 
-$(OUTPUT_DIR)/%.o: src/%.c $(HEADERS) | $(OUTPUT_DIR)
+$(LIBRARY_OUTPUT_DIR)/%.o: src/%.c $(HEADERS) | $(LIBRARY_OUTPUT_DIR)
 	$(CC) $(CFLAGS) $(PROFILE_FLAGS) -c $< -o $@
 
-$(JANSSON_A): $(HEADERS) $(OBJS) | $(OUTPUT_DIR)
+$(JANSSON_A): $(HEADERS) $(OBJS) | $(LIBRARY_OUTPUT_DIR)
+	echo $(findstring fPIC,$(CFLAGS))
 	$(AR) src $(JANSSON_A) $(OBJS)
 
 clean:
-	rm -rf $(OUTPUT_DIR) src/jansson_config.h
+	rm -rf $(LIBRARY_OUTPUT_DIR) src/jansson_config.h
 
 all: $(JANSSON_A)


### PR DESCRIPTION
In order for our xl SQL functions to be compiled into a shared library, we need to compile all files with `-fPIC` (Position Independent Code), including libraries such as this. However, PIC has performance impacts, so we don't want to always compile with `-fPIC`. So, we want to be able to compile two versions of our libraries, those to be included in the xl process and those to be included in shared objects.

I added a fall-back mechanism here, so this can be merged ahead of the XL changes.